### PR TITLE
Add new rule for lines-between-class-members

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "0.1.0-beta.7"
+  "version": "0.1.0-beta.8"
 }

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -14,7 +14,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/ban-ts-comment': 'off'
+    '@typescript-eslint/ban-ts-comment': 'off',
     'lines-between-class-members': ['error', 'always', { 'exceptAfterSingleLine': true }]
   }
 };

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -15,5 +15,6 @@ module.exports = {
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off'
+    'lines-between-class-members': ['error', 'always', { 'exceptAfterSingleLine': true }]
   }
 };

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-base",
-  "version": "0.1.0-beta.7",
+  "version": "0.1.0-beta.8",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-vue",
-  "version": "0.1.0-beta.7",
+  "version": "0.1.0-beta.8",
   "publishConfig": {
     "access": "public"
   },
@@ -10,7 +10,7 @@
     "lint": "eslint . --fix"
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.7",
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.8",
     "eslint-plugin-vue": "^9.7.0"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config",
-  "version": "0.1.0-beta.7",
+  "version": "0.1.0-beta.8",
   "publishConfig": {
     "access": "public"
   },
@@ -10,6 +10,6 @@
     "lint": "eslint . --fix"
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.7"
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.8"
   }
 }


### PR DESCRIPTION
> Should have line break between functions in the class, now its all stack together makes not friendly to scan with eyes.

