### PR TITLE
build: use from-package instead of from-git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
       - run: yarn install
-      - run: yarn lerna publish from-git --dist-tag beta --yes
+      - run: yarn lerna publish from-package --dist-tag beta --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
For some reason `from-git` no longer works and is not documented in latest version of lerna. `from-package` seems to be working.