### PR TITLE
fix: Use default print width

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-beta.14"
+  "version": "0.1.0-beta.15"
 }

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -1,6 +1,9 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
-  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended'
+  ],
   plugins: ['prettier', '@typescript-eslint', 'import'],
   parserOptions: {
     ecmaVersion: 2018,
@@ -15,7 +18,11 @@ module.exports = {
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
-    'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+    'lines-between-class-members': [
+      'error',
+      'always',
+      { exceptAfterSingleLine: true }
+    ],
     'import/no-extraneous-dependencies': 'error'
   }
 };

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-base",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-vue",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "publishConfig": {
     "access": "public"
   },
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.14",
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.15",
     "eslint-plugin-vue": "^9.18.1"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "publishConfig": {
     "access": "public"
   },
@@ -10,6 +10,6 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.14"
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.15"
   }
 }

--- a/packages/eslint-nuxt/index.js
+++ b/packages/eslint-nuxt/index.js
@@ -31,7 +31,12 @@ module.exports = {
         'vue/define-macros-order': [
           'error',
           {
-            order: ['defineOptions', 'defineProps', 'defineEmits', 'defineSlots']
+            order: [
+              'defineOptions',
+              'defineProps',
+              'defineEmits',
+              'defineSlots'
+            ]
           }
         ],
         'vue/define-props-declaration': ['error', 'type-based'],

--- a/packages/eslint-nuxt/package.json
+++ b/packages/eslint-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-nuxt",
-  "version": "0.1.0-beta.14",
+  "version": "0.1.0-beta.15",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/prettier-config/index.js
+++ b/packages/prettier-config/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   semi: true,
   singleQuote: true,
-  printWidth: 100,
   tabWidth: 2,
   trailingComma: 'none',
   arrowParens: 'avoid'

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/prettier-config",
-  "version": "0.1.0-beta.11",
+  "version": "0.1.0-beta.15",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This makes code much harder to read in my editor, specially when reviewing diffs. Let's please remove it, and use the default of 80 like it always was on `snapshot`

Left is with 80 and right is with 100:
<img width="1539" alt="image" src="https://github.com/snapshot-labs/config/assets/51686767/2d0e03c0-00fd-49fe-84d3-1cda164c95f4">


Also from the official docs:
> For readability we recommend against using more than 80 characters:

> In code styleguides, maximum line length rules are often set to 100 or 120. However, when humans write code, they don’t strive to reach the maximum number of columns on every line. Developers often use whitespace to break up long lines for readability. In practice, the average line length often ends up well below the maximum.

> Prettier’s printWidth option does not work the same way. It is not the hard upper allowed line length limit. It is a way to say to Prettier roughly how long you’d like lines to be. Prettier will make both shorter and longer lines, but generally strive to meet the specified printWidth.

> Remember, computers are dumb. You need to explicitly tell them what to do, while humans can make their own (implicit) judgements, for example on when to break a line.

> In other words, don’t try to use printWidth as if it was ESLint’s [max-len](https://eslint.org/docs/rules/max-len) – they’re not the same. max-len just says what the maximum allowed line length is, but not what the generally preferred length is – which is what printWidth specifies.