### PR TITLE
fix: import order rules

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-beta.15"
+  "version": "0.1.0-beta.16"
 }

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -46,7 +46,6 @@ module.exports = {
         'newlines-between': 'never',
         alphabetize: {
           order: 'asc',
-          orderImportKind: 'asc',
           caseInsensitive: true
         }
       }

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -37,6 +37,21 @@ module.exports = {
         groups: ['builtin', 'external', 'internal', 'type'],
         pathGroups: [
           {
+            pattern: 'vue',
+            group: 'builtin',
+            position: 'before'
+          },
+          {
+            pattern: 'vitest',
+            group: 'builtin',
+            position: 'before'
+          },
+          {
+            pattern: '@vue/**',
+            group: 'builtin',
+            position: 'before'
+          },
+          {
             pattern: '@/**',
             group: 'internal'
           }

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -28,9 +28,7 @@ module.exports = {
       'error',
       {
         ignoreCase: true,
-        ignoreDeclarationSort: true,
-        ignoreMemberSort: false,
-        memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single']
+        ignoreDeclarationSort: true
       }
     ],
     'import/order': [

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -23,6 +23,33 @@ module.exports = {
       'always',
       { exceptAfterSingleLine: true }
     ],
-    'import/no-extraneous-dependencies': 'error'
+    'import/no-extraneous-dependencies': 'error',
+    'sort-imports': [
+      'error',
+      {
+        ignoreCase: true,
+        ignoreDeclarationSort: true,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single']
+      }
+    ],
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', 'type'],
+        pathGroups: [
+          {
+            pattern: '@/**',
+            group: 'internal'
+          }
+        ],
+        'newlines-between': 'never',
+        alphabetize: {
+          order: 'asc',
+          orderImportKind: 'asc',
+          caseInsensitive: true
+        }
+      }
+    ]
   }
 };

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-base",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-vue",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "publishConfig": {
     "access": "public"
   },
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.15",
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.16",
     "eslint-plugin-vue": "^9.18.1"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "publishConfig": {
     "access": "public"
   },
@@ -10,6 +10,6 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.15"
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.16"
   }
 }

--- a/packages/eslint-nuxt/package.json
+++ b/packages/eslint-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-nuxt",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/prettier-config",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary:
Context: https://github.com/snapshot-labs/sx-monorepo/pull/383#discussion_r1687906014
Often we miss sorting imports, this should be automated with eslint rules

- Add the `sort-imports` rule to sort imports inside one file/lib
- Add the `import/order` rule to sort imports in groups in order: `['builtin', 'external', 'internal', 'type']`

## How to test:
- Go to any project, for example, in mono repo, edit package.json,
- Under `eslintConfig` add config from this PR (add double quotes)
- Change the order of imports other than `['builtin', 'external', 'internal', 'type']`, see the error

