### PR TITLE
fix: Prefer no duplicate imports and no type imports

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-beta.16"
+  "version": "0.1.0-beta.17"
 }

--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -10,6 +10,11 @@ module.exports = {
     sourceType: 'module'
   },
   rules: {
+    'import/no-duplicates': ['error', { 'prefer-inline': true }],
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      { prefer: 'no-type-imports' }
+    ],
     'prettier/prettier': 'error',
     'no-console': 'off',
     'prefer-template': 'error',

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-base",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-vue",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "publishConfig": {
     "access": "public"
   },
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.16",
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.17",
     "eslint-plugin-vue": "^9.18.1"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "publishConfig": {
     "access": "public"
   },
@@ -10,6 +10,6 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.16"
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.17"
   }
 }

--- a/packages/eslint-nuxt/package.json
+++ b/packages/eslint-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-nuxt",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/prettier-config",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Context https://github.com/snapshot-labs/sx-monorepo/pull/521#discussion_r1688763257

## Summary:
- `import/no-duplicates` to not allow duplicate imports:
  ```ts
  import { CHAIN_IDS } from '@/helpers/constants';
  import { SUPPORTED_VOTING_TYPES } from '@/helpers/constants';
  ``` 
  will resolve to
  ```ts
    import { CHAIN_IDS, SUPPORTED_VOTING_TYPES } from '@/helpers/constants';
  ```
- `@typescript-eslint/consistent-type-imports'` to not allow `import type`
   ```ts
   import type { OffchainNetworkConfig } from './types';
   ```
   will resolve to
   ```ts
    import { OffchainNetworkConfig } from './types';
    ```
## How to test:
- Go to any project, for example, in mono repo, edit package.json,
- Under `eslintConfig` add config from this PR (add double quotes)
- Try to add duplicate imports and imports with `type` keyword

## TODO:
- [x] Run `yarn release` to update versions, before merging this PR