### PR TITLE
fix: Add lint rule to enforce camelCase event name

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.0-beta.17"
+  "version": "0.1.0-beta.18"
 }

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-base",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -3,7 +3,8 @@ module.exports = {
   rules: {
     'vue/multi-word-component-names': 'off',
     'vue/require-default-prop': 'off',
-    'vue/no-v-html': 'off'
+    'vue/no-v-html': 'off',
+    'vue/custom-event-name-casing': ['error', 'camelCase']
   },
   overrides: [
     {

--- a/packages/eslint-config-vue/package.json
+++ b/packages/eslint-config-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-vue",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "publishConfig": {
     "access": "public"
   },
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.17",
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.18",
     "eslint-plugin-vue": "^9.18.1"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "publishConfig": {
     "access": "public"
   },
@@ -10,6 +10,6 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.17"
+    "@snapshot-labs/eslint-config-base": "^0.1.0-beta.18"
   }
 }

--- a/packages/eslint-nuxt/package.json
+++ b/packages/eslint-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/eslint-config-nuxt",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/prettier-config",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary:
- Add new rule to  enforce camelCase event name

Closes https://github.com/snapshot-labs/config/issues/24

## How to test:
- Go to any project, for example, in mono repo, edit package.json,
- Under `eslintConfig` add config from this PR (add double quotes)
- Try to change event to kebab case
- see error
- <img width="816" alt="Untitled 4" src="https://github.com/user-attachments/assets/891af512-9eca-4e43-a45d-be46d3e034ee">

## TODO:
- [ ] Run `yarn release` to update versions, before merging this PR
