### PR TITLE
fix: Avoid icons imports

### DIFF
--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -5,18 +5,17 @@ module.exports = {
     'vue/require-default-prop': 'off',
     'vue/no-v-html': 'off',
     'vue/custom-event-name-casing': ['error', 'camelCase'],
-    "no-restricted-imports": [
-        "error",
-        {
-          "patterns": [
-            {
-              "group": ["~icons/*"],
-              "message": "No need to import icons directly, they are auto-imported"
-            }
-          ]
-        }
-      ]
-    }
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['~icons/*'],
+            message: 'No need to import icons directly, they are auto-imported'
+          }
+        ]
+      }
+    ]
   },
   overrides: [
     {

--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -4,7 +4,19 @@ module.exports = {
     'vue/multi-word-component-names': 'off',
     'vue/require-default-prop': 'off',
     'vue/no-v-html': 'off',
-    'vue/custom-event-name-casing': ['error', 'camelCase']
+    'vue/custom-event-name-casing': ['error', 'camelCase'],
+    "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            {
+              "group": ["~icons/*"],
+              "message": "No need to import icons directly, they are auto-imported"
+            }
+          ]
+        }
+      ]
+    }
   },
   overrides: [
     {


### PR DESCRIPTION
## Summary:
Related to https://github.com/snapshot-labs/sx-monorepo/pull/577#discussion_r1703907938
- Add a new rule to avoid icon imports

Closes https://github.com/snapshot-labs/config/issues/24

## How to test:
- Go to any project, for example, in monorepo, edit package.json
- - Under `eslintConfig` add config:
```json
"no-restricted-imports": [
        "error",
        {
          "patterns": [
            {
              "group": ["~icons/*"],
              "message": "No need to import icons directly, they are auto-imported"
            }
          ]
        }
      ]
    }
```
- Try to  import icon
- see error
- <img width="804" alt="Untitled 8" src="https://github.com/user-attachments/assets/abfec8db-b781-4aef-981f-852bea6e4a1b">


## TODO:
- [ ] Run `yarn release` to update versions, before merging this PR
