### PR TITLE
feat: make unused-vars errors

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -23,6 +23,7 @@ module.exports = {
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
     'lines-between-class-members': [
       'error',
       'always',


### PR DESCRIPTION
Currently unused-vars are considered a warnings, but we always try to correct those during code review.

We can just make those errors so CI catches them.