### PR TITLE
fix: remove no-unused-vars override in vue

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -23,7 +23,6 @@ module.exports = {
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
-    '@typescript-eslint/no-unused-vars': 'error',
     'lines-between-class-members': [
       'error',
       'always',

--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -12,10 +12,6 @@ module.exports = {
       parser: 'vue-eslint-parser',
       parserOptions: {
         parser: '@typescript-eslint/parser'
-      },
-      rules: {
-        'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': 'warn'
       }
     }
   ]


### PR DESCRIPTION
no-unused-vars was actually already set to error, we just override it in vue config.

Follows up https://github.com/snapshot-labs/config/pull/28